### PR TITLE
Updated jarallax-video to always use HTTPS

### DIFF
--- a/jarallax/jarallax-video.js
+++ b/jarallax/jarallax-video.js
@@ -572,21 +572,17 @@
         // load Youtube API
         if(_this.type === 'youtube' && !YoutubeAPIadded) {
             YoutubeAPIadded = 1;
-            src = '//www.youtube.com/iframe_api';
+            src = 'https://www.youtube.com/iframe_api';
         }
 
         // load Vimeo API
         if(_this.type === 'vimeo' && !VimeoAPIadded) {
             VimeoAPIadded = 1;
-            src = '//player.vimeo.com/api/player.js';
+            src = 'https://player.vimeo.com/api/player.js';
         }
 
         if(!src) {
             return;
-        }
-
-        if (window.location.origin === 'file://') {
-            src = 'http:' + src;
         }
 
         // add script in head section


### PR DESCRIPTION
Hey Nikita,

Thanks for the great JS library! This pull request updates jarallax-video to always use the HTTPS protocol for Youtube and Vimeo. Both Youtube and Vimeo enforce HTTPS - attempting to request a video over HTTP will always result in a redirect, causing an unnecessary performance penalty when running Jarallax on an HTTP site.

Additionally, the existing protocol relative URLs get in the way of [Content Security Policies](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) that only whitelist Youtube/Vimeo over HTTPS. In this situation, a video will be blocked from loading when a developer is working on `localhost` (over HTTP), but be allowed to load in a production environment with HTTPS configured.