### PR TITLE
Add TypeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Just Another Parallax
-Smooth parallax scrolling effect for background images, videos and inline elements. Code in pure JavaScript with ***NO dependencies*** + jQuery supported. ***Youtube***, ***Vimeo*** and ***Local Videos*** parallax supported.
+Smooth parallax scrolling effect for background images, videos and inline elements. Code in pure JavaScript with ***NO dependencies*** + jQuery supported. ***YouTube***, ***Vimeo*** and ***Local Videos*** parallax supported.
 
 ## [Demo](https://free.nkdev.info/jarallax/)
 
@@ -166,7 +166,7 @@ keepImg | boolean | `false` | Keep `<img>` tag in it's default place after Jaral
 elementInViewport | dom | `null` | Use custom DOM / jQuery element to check if parallax block in viewport. More info here - [Issue 13](https://github.com/nk-o/jarallax/issues/13).
 zIndex | number | `-100` | z-index of parallax container.
 noAndroid | boolean | `false` | Disable parallax on Android devices.
-noIos | boolean | `false` | Disable parallax on iOs devices.
+noIos | boolean | `false` | Disable parallax on iOS devices.
 
 ### Options For Video (+ supported all default options)
 Required `jarallax/jarallax-video.js` file.

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
         "video"
     ],
     "devDependencies": {
-        "babel-preset-env": "^1.6.0",
+        "@types/jquery": "^3.3.0",
         "babel": "^6.23.0",
+        "babel-preset-env": "^1.6.0",
         "del": "^2.2.2",
         "eslint": "^4.6.0",
         "eslint-config-airbnb": "^15.1.0",
@@ -40,17 +41,17 @@
         "eslint-plugin-jsx-a11y": "^5.1.1",
         "eslint-plugin-react": "^7.4.0",
         "gulp": "^3.9.1",
+        "gulp-babel": "^6.1.2",
         "gulp-header": "^1.8.9",
         "gulp-if": "^2.0.2",
         "gulp-iife": "^0.3.0",
         "gulp-load-plugins": "^1.5.0",
-        "gulp-babel": "^6.1.2",
         "gulp-rename": "^1.2.2",
         "gulp-uglify": "^2.0.0",
-        "node-qunit-phantomjs": "^1.5.0",
-        "qunitjs": "^2.4.0",
-        "json-file": "^0.1.0",
         "jquery": "^3.2.1",
-        "object-fit-images": "^3.2.3"
+        "json-file": "^0.1.0",
+        "node-qunit-phantomjs": "^1.5.0",
+        "object-fit-images": "^3.2.3",
+        "qunitjs": "^2.4.0"
     }
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -42,7 +42,7 @@ interface JarallaxOptions {
     /**
      * Image tag that will be used as background.
      */
-    imgElement?: string;
+    imgElement?: string | Element;
 
     /**
      * Image size. If you use <img> tag for background, you should add object-fit values, else use background-size

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,195 @@
+// Type definitions for jarallax 1.9.3
+// Project: https://github.com/nk-o/jarallax
+// Definitions by: Dave Macaulay <https://github.com/davemacaulay>
+// TypeScript Version: 2.3
+
+/// <reference types="jquery"/>
+
+/**
+ * Scroll calculations used by onScroll event
+ */
+interface JarallaxOnScrollCalculations {
+    rect: object;
+    beforeTop: number;
+    beforeTopEnd: number;
+    afterTop: number;
+    beforeBottom: number;
+    beforeBottomEnd: number;
+    afterBottom: number;
+    visiblePercent: number;
+    fromViewportCenter: number;
+}
+
+/**
+ * Configurable options for Jarallax
+ */
+interface JarallaxOptions {
+    /**
+     * scroll, scale, opacity, scroll-opacity, scale-opacity.
+     */
+    type?: string;
+
+    /**
+     * Parallax effect speed. Provide numbers from -1.0 to 2.0.
+     */
+    speed?: number;
+
+    /**
+     * Image url. By default used image from background.
+     */
+    imgSrc?: string;
+
+    /**
+     * Image tag that will be used as background.
+     */
+    imgElement?: string;
+
+    /**
+     * Image size. If you use <img> tag for background, you should add object-fit values, else use background-size
+     * values.
+     */
+    imgSize?: string;
+
+    /**
+     * Image position. If you use <img> tag for background, you should add object-position values, else use
+     * background-position values.
+     */
+    imgPosition?: string;
+
+    /**
+     * Image repeat. Supported only background-position values.
+     */
+    imgRepeat?: "repeat" | "no-repeat";
+
+    /**
+     * Keep <img> tag in it's default place after Jarallax inited.
+     */
+    keepImg?: boolean;
+
+    /**
+     * Use custom DOM / jQuery element to check if parallax block in viewport.
+     * More info here - https://github.com/nk-o/jarallax/issues/13.
+     */
+    elementInViewport?: Element | JQuery<Element>;
+
+    /**
+     * z-index of parallax container.
+     */
+    zIndex?: number;
+
+    /**
+     * Disable parallax on Android devices.
+     */
+    noAndroid?: boolean;
+
+    /**
+     * Disable parallax on iOS devices.
+     */
+    noIos?: boolean;
+
+    /**
+     * You can use Youtube, Vimeo or local videos. Also you can use data attribute data-jarallax-video.
+     */
+    videoSrc?: string;
+
+    /**
+     * Start time in seconds when video will be started (this value will be applied also after loop).
+     */
+    videoStartTime?: number;
+
+    /**
+     * End time in seconds when video will be ended.
+     */
+    videoEndTime?: number;
+
+    /**
+     * Video volume from 0 to 100.
+     */
+    videoVolumne?: number;
+
+    /**
+     * Play video only when it is visible on the screen.
+     */
+    videoPlayOnlyVisible?: boolean;
+
+    /**
+     * Called when parallax working. Use first argument with calculations.
+     * More info https://github.com/nk-o/jarallax#onscroll-event.
+     *
+     * @param {JarallaxOnScrollCalculations} calculations
+     */
+    onScroll?: (calculations: JarallaxOnScrollCalculations) => void;
+
+    /**
+     * Called after init end.
+     */
+    onInit?: () => void;
+
+    /**
+     * Called after destroy.
+     */
+    onDestroy?: () => void;
+
+    /**
+     * Called after cover image.
+     */
+    onCoverImage?: () => void;
+}
+
+/**
+ * Main invocation of Jarallax
+ *
+ * @param {Element | Element[] | NodeListOf<Element> | JQuery<Element>} elements
+ * @param {JarallaxOptions} userOptions
+ */
+declare function jarallax(
+    elements: Element | Element[] | NodeListOf<Element> | JQuery<Element>,
+    userOptions: JarallaxOptions,
+): void;
+
+/**
+ * Void callable methods
+ *
+ * @param {Element | Element[] | NodeListOf<Element> | JQuery<Element>} elements
+ * @param {"destroy" | "onResize" | "onScroll"} methodName
+ */
+declare function jarallax(
+    elements: Element | Element[] | NodeListOf<Element> | JQuery<Element>,
+    methodName: "destroy" | "onResize" | "onScroll",
+): void;
+
+/**
+ * Is visible method
+ *
+ * @param {Element | Element[] | NodeListOf<Element> | JQuery<Element>} elements
+ * @param {"isVisible"} methodName
+ * @returns {boolean}
+ */
+declare function jarallax(
+    elements: Element | Element[] | NodeListOf<Element> | JQuery<Element>,
+    methodName: "isVisible",
+): boolean;
+
+interface JQuery {
+    /**
+     * Init Jarallax with options
+     *
+     * @param {JarallaxOptions} userOptions
+     */
+    jarallax(userOptions: JarallaxOptions): void;
+
+    /**
+     * Run a method on the current instance of Jaralax
+     *
+     * @param {"destroy" | "onResize" | "onScroll"} methodName
+     */
+    jarallax(methodName: "destroy" | "onResize" | "onScroll"): void;
+
+    /**
+     * Check if an element is visible
+     *
+     * @param {"isVisible"} methodName
+     * @returns {boolean}
+     */
+    jarallax(methodName: "isVisible"): boolean;
+}


### PR DESCRIPTION
This PR adds basic TypeScript support for Jarallax usage from the window & whilst using jQuery.

You'll need to ensure your instance includes the definition file for the typings to become available. 

**Note:** I'll look to get this setup as a `@types/jarallax` package at some point. 

*Also fixed some capitalisation in the README*.