### PR TITLE
include typings in distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jarallax",
-    "version": "1.12.8",
+    "version": "1.12.7",
     "description": "Smooth parallax scrolling effect for background images, videos and inline elements. Code in pure JavaScript with NO dependencies + jQuery supported. Youtube, Vimeo and Local Videos parallax supported.",
     "license": "MIT",
     "homepage": "https://github.com/nk-o/jarallax",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jarallax",
-    "version": "1.12.7",
+    "version": "1.12.8",
     "description": "Smooth parallax scrolling effect for background images, videos and inline elements. Code in pure JavaScript with NO dependencies + jQuery supported. Youtube, Vimeo and Local Videos parallax supported.",
     "license": "MIT",
     "homepage": "https://github.com/nk-o/jarallax",
@@ -9,7 +9,8 @@
     "types": "./typings/index.d.ts",
     "files": [
         "src",
-        "dist"
+        "dist",
+        "typings"
     ],
     "scripts": {
         "dev": "gulp dev",


### PR DESCRIPTION
The types are not getting included in the distribution so I change the `"files"` array in `package.json` to:

```json
    "files": [
        "src",
        "dist",
        "typings"
    ],
```
