### PR TITLE
docs: switch cdns to jsdelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ We provide a version of Jarallax built as ESM (jarallax.esm.js and jarallax.esm.
 </script>
 ```
 
-### ESM + [Skypack](https://www.skypack.dev/)
+#### ESM CDN
 
 ```html
 <script type="module">
-  import { jarallax, jarallaxVideo } from "https://cdn.skypack.dev/jarallax@2.0?min";
+  import { jarallax, jarallaxVideo } from "https://cdn.jsdelivr.net/npm/jarallax@2/+esm";
 
   // Optional video extension
   jarallaxVideo();
@@ -82,13 +82,13 @@ Jarallax may be also used in a traditional way by including script in HTML and u
 <script src="jarallax-video.min.js"></script>
 ```
 
-### UMD + [UNPKG](https://unpkg.com/)
+#### UMD CDN
 
 ```html
-<script src="https://unpkg.com/jarallax@2.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/jarallax@2/dist/jarallax.min.js"></script>
 
 <!-- Optional video extension -->
-<script src="https://unpkg.com/jarallax@2.0/dist/jarallax-video.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jarallax@2/dist/jarallax-video.min.js"></script>
 ```
 
 ### CJS (Bundlers like Webpack)

--- a/examples/es-modules/index.html
+++ b/examples/es-modules/index.html
@@ -10,7 +10,7 @@
     <link href="./style.css" rel="stylesheet" />
 
     <!-- Jarallax CSS -->
-    <link href="https://unpkg.com/jarallax@2.0/dist/jarallax.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/jarallax@2/dist/jarallax.css" rel="stylesheet" />
   </head>
   <body>
     <div class="section"><h1>ES Modules Example</h1></div>
@@ -25,7 +25,7 @@
 
     <!-- Init Jarallax -->
     <script type="module">
-      import { jarallax, jarallaxVideo } from "https://cdn.skypack.dev/jarallax@2.0?min";
+      import { jarallax, jarallaxVideo } from "https://cdn.jsdelivr.net/npm/jarallax@2/+esm";
 
       // Optional video extension
       jarallaxVideo();

--- a/examples/html/index.html
+++ b/examples/html/index.html
@@ -10,7 +10,7 @@
     <link href="./style.css" rel="stylesheet" />
 
     <!-- Jarallax CSS -->
-    <link href="https://unpkg.com/jarallax@2.0/dist/jarallax.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/jarallax@2/dist/jarallax.css" rel="stylesheet" />
   </head>
   <body>
     <div class="section"><h1>HTML Example</h1></div>
@@ -24,7 +24,7 @@
     <div class="section"></div>
 
     <!-- Jarallax JS -->
-    <script src="https://unpkg.com/jarallax@2.0"></script>
-    <script src="https://unpkg.com/jarallax@2.0/dist/jarallax-video.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jarallax@2/dist/jarallax.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jarallax@2/dist/jarallax-video.min.js"></script>
   </body>
 </html>

--- a/examples/javascript/index.html
+++ b/examples/javascript/index.html
@@ -10,7 +10,7 @@
     <link href="./style.css" rel="stylesheet" />
 
     <!-- Jarallax CSS -->
-    <link href="https://unpkg.com/jarallax@2.0/dist/jarallax.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/jarallax@2/dist/jarallax.css" rel="stylesheet" />
   </head>
   <body>
     <div class="section"><h1>JavaScript Example</h1></div>
@@ -24,8 +24,8 @@
     <div class="section"></div>
 
     <!-- Jarallax JS -->
-    <script src="https://unpkg.com/jarallax@2.0"></script>
-    <script src="https://unpkg.com/jarallax@2.0/dist/jarallax-video.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jarallax@2/dist/jarallax.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jarallax@2/dist/jarallax-video.min.js"></script>
 
     <!-- Init Jarallax -->
     <script type="text/javascript">

--- a/examples/jquery/index.html
+++ b/examples/jquery/index.html
@@ -10,7 +10,7 @@
     <link href="./style.css" rel="stylesheet" />
 
     <!-- Jarallax CSS -->
-    <link href="https://unpkg.com/jarallax@2.0/dist/jarallax.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/jarallax@2/dist/jarallax.css" rel="stylesheet" />
   </head>
   <body>
     <div class="section"><h1>jQuery Example</h1></div>
@@ -24,11 +24,11 @@
     <div class="section"></div>
 
     <!-- jQuery -->
-    <script src="https://unpkg.com/jquery"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery"></script>
 
     <!-- Jarallax JS -->
-    <script src="https://unpkg.com/jarallax@2.0"></script>
-    <script src="https://unpkg.com/jarallax@2.0/dist/jarallax-video.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jarallax@2/dist/jarallax.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jarallax@2/dist/jarallax-video.min.js"></script>
 
     <!-- Init Jarallax -->
     <script type="text/javascript">


### PR DESCRIPTION
unpkg is unmaintained and [full of issues](https://github.com/mjackson/unpkg/issues). I switched the documentation over to [jsDelivr](https://www.jsdelivr.com/) since it's actively maintained and is much more reliable due to its [fallback system](https://www.jsdelivr.com/network/infographic) using multiple CDNs.

Likewise, Skypack is also [unmaintained](https://github.com/skypackjs/skypack-cdn/issues), so that was switched over to [esm.run](https://www.jsdelivr.com/esm), which is still part of the jsDelivr network.

Let me know if there are any concerns!