### PR TITLE
FIX: Module '"jarallax"' has no exported member 'jarallaxVideo' error

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -182,6 +182,13 @@ export function jarallax(
 ): void;
 
 /**
+ * Invocation of jarallaxVideo
+ *
+ * @param {typeof jarallax} jarallaxInstance
+ */
+export function jarallaxVideo(jarallaxInstance?: typeof jarallax): void
+
+/**
  * Void callable methods
  *
  * @param {Element | Element[] | NodeListOf<Element> | JQuery<Element>} elements


### PR DESCRIPTION
This PR contains FIX for the Typescript error 

> Module '"jarallax"' has no exported member 'jarallaxVideo' 

only typings/index.d.ts has been modified