### PR TITLE
Fix data-video-volume="0" leaving the video unmuted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- fixed `data-video-volume="0"` leaving the video unmuted, which blocked background autoplay on mobile
+
 ## [3.0.1] - Jun 9, 2026
 
 - updated `video-worker` and dev dependencies

--- a/src/ext-video.ts
+++ b/src/ext-video.ts
@@ -155,7 +155,8 @@ function jarallaxVideo(jarallax: JarallaxStatic | undefined = global.jarallax): 
       accessibilityHidden: true,
       startTime: Number(this.options.videoStartTime || 0),
       endTime: Number(this.options.videoEndTime || 0),
-      mute: !this.options.videoVolume,
+      // `data-video-volume` reaches us as a string, and "0" is truthy. Compare the number.
+      mute: !Number(this.options.videoVolume),
       volume: Number(this.options.videoVolume || 0),
     });
 

--- a/tests/video-dom.test.js
+++ b/tests/video-dom.test.js
@@ -117,4 +117,24 @@ describe('jarallax video DOM integration', () => {
       expect(inserted.getAttribute('poster')).toContain('https://via.placeholder.com/100x50');
     }
   });
+
+  // https://github.com/nk-o/jarallax/issues/227
+  it.each([
+    ['0', true],
+    ['30', false],
+  ])('mutes based on the numeric value of data-video-volume="%s"', async (attr, expectedMute) => {
+    const { default: jarallax } = await import('../src/core.ts');
+    const { default: jarallaxVideo } = await import('../src/ext-video.ts');
+    const block = createJarallaxBlock({ mode: 'img' });
+    block.setAttribute('data-video-src', 'https://youtu.be/mru3Q5m4lkY');
+    block.setAttribute('data-video-volume', attr);
+
+    jarallaxVideo(jarallax);
+    jarallax(block);
+
+    const [worker] = videoWorkerState.instances;
+
+    expect(worker.options.mute).toBe(expectedMute);
+    expect(worker.options.volume).toBe(Number(attr));
+  });
 });


### PR DESCRIPTION
Fixes #227.

Options that arrive through `data-*` attributes are always strings, and core only normalizes `"true"` and `"false"` into real booleans — numbers stay as text. The video extension then decided muting with `!this.options.videoVolume`, and the string `"0"` is truthy, so a background video whose author had explicitly set `data-video-volume="0"` was handed to VideoWorker with `mute: false`. Comparing the number instead fixes it, and matches the very next line, which already wraps the same option in `Number()`.

That is also why the reporter's workaround worked: passing `videoVolume: 0` through the JavaScript options gives a real number, so `!0` is `true` and the player gets muted.

| | `data-video-volume="0"` | `videoVolume: 0` in JS |
| --- | --- | --- |
| option value | `"0"` (string) | `0` (number) |
| VideoWorker `mute` | `false` | `true` |
| YouTube `isMuted()` | `false` | `true` |

## Why it only showed up on phones

Desktop Chrome treats a zero volume as effectively muted, so the video still autoplays there and the bug stays invisible. Mobile browsers gate autoplay on the actual muted flag, which is never set — hence "shows the YouTube UI with a loading wheel and never plays".

I verified the option-level defect and the fix in Chrome 151 with the markup from the issue. I could not reproduce the mobile playback failure itself: neither desktop Chrome nor Pixel emulation reproduces a real phone's media stack, and both play the video in either state. The mechanism above is what the evidence supports.

The regression test covers both values and fails on `master` with `expected false to be true`. `npm run lint`, `npm run typecheck` and `npm run test:run` (41 tests) pass.