### PR TITLE
chore(git): collapse generated output in diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,7 @@
 *.svg   text eol=lf
 *.txt   text eol=lf
 *.yml   text eol=lf
+
+# Generated build output. Hidden in pull request diffs and excluded from the
+# language statistics — rebuild it with `npm run build`, never edit by hand.
+dist/** -diff linguist-generated=true


### PR DESCRIPTION
`dist/` is committed but generated by `npm run build`, so it shows up as the bulk of every pull request that touches source and skews the language statistics on the repository page. Marking it generated collapses it in the diff view and drops it from the stats — the same treatment ghostkit got in nk-o/ghostkit#237.

`-diff` hides the contents, `linguist-generated=true` handles the collapsing and the stats. Nothing about how the files are produced or committed changes; the build still writes them and releases still carry them.

The existing `eol=lf` block is untouched.