### PR TITLE
Honor prefers-reduced-motion automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- added automatic `prefers-reduced-motion` support, which stops the parallax movement and keeps the background video from loading
+- added `videoYoutubeHost` and `videoVimeoHost` options, passed through to video-worker
+- updated `video-worker` to 3.1.0, which fixes Vimeo backgrounds playing muted in Chrome and moves YouTube off the nocookie host
 - fixed `data-video-volume="0"` leaving the video unmuted, which blocked background autoplay on mobile
 
 ## [3.0.1] - Jun 9, 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- added automatic `prefers-reduced-motion` support, which stops the parallax movement and keeps the background video from loading
+- added automatic `prefers-reduced-motion` support, which stops the parallax movement and background video playback, falling back to the provider thumbnail, the author's image, or the video's own first frame
 - added `videoYoutubeHost` and `videoVimeoHost` options, passed through to video-worker
 - updated `video-worker` to 3.1.0, which fixes Vimeo backgrounds playing muted in Chrome and moves YouTube off the nocookie host
 - fixed `data-video-volume="0"` leaving the video unmuted, which blocked background autoplay on mobile

--- a/README.md
+++ b/README.md
@@ -421,11 +421,20 @@ jarallax(document.querySelectorAll('.jarallax'), {
 
 ### Reduced motion
 
-Nothing to configure. When the reader's system asks for reduced motion, Jarallax stops on its own: the image is still covered and positioned, it just does not move with the scroll, and a background video is never loaded — the poster stays on screen instead.
+Nothing to configure. When the reader's system asks for reduced motion, Jarallax stops on its own: the image is still covered and positioned, it just does not move with the scroll, and background video never plays. The block always keeps something to look at:
 
-This matches what `disableParallax: true` and `disableVideo: true` already do, so the layout is the same one those paths have always produced. It is read from `(prefers-reduced-motion: reduce)` when the instance is created; changing the system setting applies on the next page load.
+| Background | Reduced motion shows |
+| :--- | :--- |
+| Image | The image, positioned as usual, not moving |
+| YouTube / Vimeo | The provider thumbnail; the player iframe is never requested |
+| Self-hosted, with a fallback image | That image; the video is never requested |
+| Self-hosted, no fallback image | The video's own first frame, inserted paused |
 
-Give background videos a fallback image (`imgSrc`, a `.jarallax-img` element, or a CSS `background-image`). YouTube and Vimeo backgrounds fall back to the provider thumbnail automatically, but a self-hosted video has no thumbnail to borrow.
+The parallax side matches what `disableParallax: true` already does, so the layout is the one that path has always produced. `disableVideo` keeps meaning only what you asked for — reduced motion is decided separately, because what replaces the video depends on the provider.
+
+A fallback image (`imgSrc`, a `.jarallax-img` element, or a CSS `background-image`) is still worth adding for a self-hosted video: it gives you control over the frame and it loads faster than the video does.
+
+Read from `(prefers-reduced-motion: reduce)` when the instance is created; changing the system setting applies on the next page load.
 
 ### Additional options for video extension
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Parallax scrolling for modern browsers. Supported &lt;img&gt; tags, background i
   - [A. JavaScript way](#a-javascript-way-1)
   - [B. Data attribute way](#b-data-attribute-way-1)
 - [Options](#options)
+  - [Reduced motion](#reduced-motion)
   - [Disable on mobile devices](#disable-on-mobile-devices)
   - [Additional options for video extension](#additional-options-for-video-extension)
 - [Events](#events)
@@ -418,6 +419,14 @@ jarallax(document.querySelectorAll('.jarallax'), {
 });
 ```
 
+### Reduced motion
+
+Nothing to configure. When the reader's system asks for reduced motion, Jarallax stops on its own: the image is still covered and positioned, it just does not move with the scroll, and a background video is never loaded — the poster stays on screen instead.
+
+This matches what `disableParallax: true` and `disableVideo: true` already do, so the layout is the same one those paths have always produced. It is read from `(prefers-reduced-motion: reduce)` when the instance is created; changing the system setting applies on the next page load.
+
+Give background videos a fallback image (`imgSrc`, a `.jarallax-img` element, or a CSS `background-image`). YouTube and Vimeo backgrounds fall back to the provider thumbnail automatically, but a self-hosted video has no thumbnail to borrow.
+
 ### Additional options for video extension
 
 Requires the video extension bundle. In package-based apps call `jarallaxVideo()` after importing from `jarallax`. In script-tag usage load `dist/jarallax-video(.min).js` after the core bundle.
@@ -431,6 +440,8 @@ videoEndTime | float | `0` | End time in seconds when video will be ended.
 videoLoop | boolean | `true` | Loop video to play infinitely.
 videoPlayOnlyVisible | boolean | `true` | Play video only when it is visible on the screen.
 videoLazyLoading | boolean | `true` | Preload videos only when it is visible on the screen.
+videoYoutubeHost | string | - | Origin the YouTube embed is loaded from, for example `https://www.youtube-nocookie.com`. Left empty, video-worker picks its own default.
+videoVimeoHost | string | - | Origin the Vimeo embed is loaded from. Left empty, video-worker picks its own default.
 disableVideo | boolean / RegExp / function | - | Disable video load on specific user agents (using regular expression) or with function return value. The image will be set on the background.
 
 ## Events

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
-        "video-worker": "^3.0.1"
+        "video-worker": "^3.1.0"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.16",
@@ -4518,9 +4518,9 @@
       }
     },
     "node_modules/video-worker": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/video-worker/-/video-worker-3.0.1.tgz",
-      "integrity": "sha512-J5a5E2/E3eZfIw+A/uBsEKGmxsIQR3kaw0kOiBsQKyeU8WR+9zFufu6ZFIn4QKhmsAN5Yi2TUxLmBRRQYGfPeg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/video-worker/-/video-worker-3.1.0.tgz",
+      "integrity": "sha512-OyhVS4mmMpopD24eECvmhsXURm5rpofDyTIRIiDfzD2JrdufFer0YaxnR4dXwWzk6k75fTBNp8cY9OuQabHfew==",
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -76,13 +76,13 @@
   ],
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
-    "@types/react": "^19.2.17",
-    "@types/react-dom": "^19.2.3",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-replace": "^6.0.3",
     "@rollup/plugin-terser": "^1.0.0",
     "@types/jquery": "^4.0.1",
     "@types/node": "^25.9.2",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "@vitest/coverage-v8": "^4.1.8",
     "clean-css": "^5.3.3",
     "cross-env": "^10.1.0",
@@ -105,6 +105,6 @@
     "react-dom": ">=18.0.0"
   },
   "dependencies": {
-    "video-worker": "^3.0.1"
+    "video-worker": "^3.1.0"
   }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -5,6 +5,7 @@ import extend from './utils/extend';
 import getParents from './utils/getParents';
 import getWindowSize from './utils/getWindowSize';
 import { addObserver, removeObserver } from './utils/observer';
+import prefersReducedMotion from './utils/prefersReducedMotion';
 import type {
   DisableOption,
   JarallaxCoverImageData,
@@ -109,12 +110,19 @@ class Jarallax {
     });
 
     this.options.speed = Math.min(2, Math.max(-1, parseFloat(`${this.options.speed}`)));
-    this.options.disableParallax = resolveDisableOption(
+
+    // Readers who ask for reduced motion get the same treatment as `disableParallax: true`:
+    // the image is still covered and positioned, it just never moves with the scroll.
+    const disableParallax = resolveDisableOption(
       userOptions?.disableParallax ?? this.options.disableParallax
     );
-    this.options.disableVideo = resolveDisableOption(
+    this.options.disableParallax = () => prefersReducedMotion() || disableParallax();
+    // Same for the background video: it is never inserted, so the poster the instance already
+    // shows stays on screen and the provider player is never downloaded.
+    const disableVideo = resolveDisableOption(
       userOptions?.disableVideo ?? this.options.disableVideo
     );
+    this.options.disableVideo = () => prefersReducedMotion() || disableVideo();
 
     // `elementInViewport` historically accepts a DOM node or a jQuery-like collection.
     let elementInVP = this.options.elementInViewport;

--- a/src/core.ts
+++ b/src/core.ts
@@ -117,12 +117,13 @@ class Jarallax {
       userOptions?.disableParallax ?? this.options.disableParallax
     );
     this.options.disableParallax = () => prefersReducedMotion() || disableParallax();
-    // Same for the background video: it is never inserted, so the poster the instance already
-    // shows stays on screen and the provider player is never downloaded.
-    const disableVideo = resolveDisableOption(
+
+    // Reduced motion stops background video too, but what to show instead depends on the
+    // provider, so that decision lives in the video extension and this option keeps meaning
+    // only what the author asked for.
+    this.options.disableVideo = resolveDisableOption(
       userOptions?.disableVideo ?? this.options.disableVideo
     );
-    this.options.disableVideo = () => prefersReducedMotion() || disableVideo();
 
     // `elementInViewport` historically accepts a DOM node or a jQuery-like collection.
     let elementInVP = this.options.elementInViewport;

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -22,6 +22,10 @@ const defaults: JarallaxOptions = {
   videoStartTime: 0,
   videoEndTime: 0,
   videoVolume: 0,
+
+  // Empty means "whatever video-worker defaults to", so the host is not pinned in two places.
+  videoYoutubeHost: '',
+  videoVimeoHost: '',
   videoLoop: true,
   videoPlayOnlyVisible: true,
   videoLazyLoading: true,

--- a/src/ext-video.ts
+++ b/src/ext-video.ts
@@ -2,6 +2,16 @@ import VideoWorker from 'video-worker';
 
 import type { JarallaxCoverImageData, JarallaxInstance, JarallaxStatic } from './types';
 import global from './utils/global';
+import prefersReducedMotion from './utils/prefersReducedMotion';
+
+// Under reduced motion a provider iframe buys nothing — its thumbnail is already painted as the
+// background — but a self-hosted video with no fallback image is the only thing that element has
+// to show, so it is inserted paused and the browser paints its first frame.
+function isPosterOnlyVideo(instance: JarallaxInstance): boolean {
+  return (
+    prefersReducedMotion() && instance.video?.type === 'local' && !instance.defaultInitImgResult
+  );
+}
 
 function jarallaxVideo(jarallax: JarallaxStatic | undefined = global.jarallax): void {
   if (typeof jarallax === 'undefined') {
@@ -15,11 +25,13 @@ function jarallaxVideo(jarallax: JarallaxStatic | undefined = global.jarallax): 
   Jarallax.prototype.onScroll = function onScrollWithVideo(this: JarallaxInstance): void {
     defOnScroll.apply(this);
 
+    const posterOnly = isPosterOnlyVideo(this);
     const isReady =
       !this.isVideoInserted &&
       this.video &&
       (!this.options.videoLazyLoading || this.isElementInViewport) &&
-      !this.options.disableVideo();
+      !this.options.disableVideo() &&
+      (!prefersReducedMotion() || posterOnly);
 
     if (!isReady) {
       return;
@@ -49,8 +61,13 @@ function jarallaxVideo(jarallax: JarallaxStatic | undefined = global.jarallax): 
       this.$video = insertedVideo;
 
       // Self-hosted video should keep using the image as a poster, just like the legacy extension did.
+      // In the poster-only case that image is the transparent placeholder, and setting it would
+      // cover the very frame this element was inserted to show, so it is left off and the video
+      // is stretched to cover by itself — `started` never fires to hand it to coverImage().
       if (this.video?.type === 'local') {
-        if (this.image.src) {
+        if (posterOnly) {
+          this.css(insertedVideo, { objectFit: 'cover' });
+        } else if (this.image.src) {
           insertedVideo.setAttribute('poster', this.image.src);
         } else if (this.image.$item?.tagName === 'IMG') {
           insertedVideo.setAttribute('poster', (this.image.$item as HTMLImageElement).src);
@@ -149,7 +166,9 @@ function jarallaxVideo(jarallax: JarallaxStatic | undefined = global.jarallax): 
     }
 
     const video = new VideoWorker(this.options.videoSrc, {
-      autoplay: true,
+      // Self-hosted players autoplay themselves once metadata lands, so this is what keeps a
+      // poster-only video paused.
+      autoplay: !prefersReducedMotion(),
       loop: this.options.videoLoop,
       showControls: false,
       accessibilityHidden: true,
@@ -209,6 +228,11 @@ function jarallaxVideo(jarallax: JarallaxStatic | undefined = global.jarallax): 
     }
 
     video.on('ready', () => {
+      // Nothing starts on its own under reduced motion, so the visibility hook is never installed.
+      if (prefersReducedMotion()) {
+        return;
+      }
+
       // Visibility-driven play/pause is applied by wrapping the existing onScroll implementation.
       if (this.options.videoPlayOnlyVisible) {
         const oldOnScroll = this.onScroll;

--- a/src/ext-video.ts
+++ b/src/ext-video.ts
@@ -158,6 +158,9 @@ function jarallaxVideo(jarallax: JarallaxStatic | undefined = global.jarallax): 
       // `data-video-volume` reaches us as a string, and "0" is truthy. Compare the number.
       mute: !Number(this.options.videoVolume),
       volume: Number(this.options.videoVolume || 0),
+      // video-worker ignores undefined, so an unset host keeps its own default.
+      youtubeHost: this.options.videoYoutubeHost || undefined,
+      vimeoHost: this.options.videoVimeoHost || undefined,
     });
 
     this.options.onVideoWorkerInit?.call(this, video);

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,8 @@ export interface JarallaxOptions {
   videoStartTime?: number | string;
   videoEndTime?: number | string;
   videoVolume?: number | string;
+  videoYoutubeHost?: string;
+  videoVimeoHost?: string;
   videoLoop?: boolean;
   videoPlayOnlyVisible?: boolean;
   videoLazyLoading?: boolean;
@@ -93,6 +95,8 @@ export interface JarallaxResolvedOptions
   videoStartTime: number | string;
   videoEndTime: number | string;
   videoVolume: number | string;
+  videoYoutubeHost: string;
+  videoVimeoHost: string;
   videoLoop: boolean;
   videoPlayOnlyVisible: boolean;
   videoLazyLoading: boolean;

--- a/src/utils/prefersReducedMotion.ts
+++ b/src/utils/prefersReducedMotion.ts
@@ -1,0 +1,16 @@
+import global from './global';
+
+let query: MediaQueryList | null | undefined;
+
+// `matches` stays live on the MediaQueryList, so the object is resolved once and read on demand.
+// Resolving lazily keeps the module import-safe in SSR and in environments without matchMedia.
+export default function prefersReducedMotion(): boolean {
+  if (typeof query === 'undefined') {
+    query =
+      typeof global.matchMedia === 'function'
+        ? global.matchMedia('(prefers-reduced-motion: reduce)')
+        : null;
+  }
+
+  return query?.matches ?? false;
+}

--- a/src/video-worker.d.ts
+++ b/src/video-worker.d.ts
@@ -8,6 +8,8 @@ declare module 'video-worker' {
     endTime?: number;
     mute?: boolean;
     volume?: number;
+    youtubeHost?: string;
+    vimeoHost?: string;
   }
 
   export type VideoWorkerEvent = 'ready' | 'started' | 'ended' | 'error';

--- a/tests/reduced-motion.test.js
+++ b/tests/reduced-motion.test.js
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createJarallaxBlock } from './test-helpers.js';
+
+const videoWorkerState = vi.hoisted(() => ({
+  instances: [],
+}));
+
+vi.mock('video-worker', () => {
+  class FakeVideoWorker {
+    constructor(source, options) {
+      this.source = source;
+      this.options = options;
+      this.handlers = new Map();
+      this.type = source.includes('vimeo.com') ? 'vimeo' : 'youtube';
+      this.videoID = 'mru3Q5m4lkY';
+      this.videoWidth = 1280;
+      this.videoHeight = 720;
+      videoWorkerState.instances.push(this);
+    }
+
+    isValid() {
+      return true;
+    }
+
+    on(event, callback) {
+      this.handlers.set(event, callback);
+    }
+
+    getImageURL(callback) {
+      callback('https://img.youtube.com/vi/mru3Q5m4lkY/maxresdefault.jpg');
+    }
+
+    getVideo(callback) {
+      const hidden = document.createElement('div');
+      const iframe = document.createElement('iframe');
+      hidden.appendChild(iframe);
+      document.body.appendChild(hidden);
+      callback(iframe);
+    }
+
+    play = vi.fn();
+
+    pause = vi.fn();
+  }
+
+  return { default: FakeVideoWorker };
+});
+
+// Only `(prefers-reduced-motion: reduce)` is answered; everything else stays false, which is
+// what jsdom would report if it implemented matchMedia at all.
+function stubReducedMotion(reduce) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query) => ({
+      media: query,
+      matches: reduce && query === '(prefers-reduced-motion: reduce)',
+      addEventListener() {},
+      removeEventListener() {},
+    }))
+  );
+}
+
+describe('prefers-reduced-motion', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    videoWorkerState.instances.length = 0;
+  });
+
+  it.each([
+    [true, false],
+    [false, true],
+  ])('reduce=%s -> parallax container created: %s', async (reduce, expectContainer) => {
+    stubReducedMotion(reduce);
+
+    const { default: jarallax } = await import('../src/core.ts');
+    const block = createJarallaxBlock({ mode: 'background' });
+
+    jarallax(block);
+
+    expect(Boolean(block.querySelector('.jarallax-container'))).toBe(expectContainer);
+    expect(block.jarallax.options.disableParallax()).toBe(reduce);
+  });
+
+  it.each([
+    [true, false],
+    [false, true],
+  ])('reduce=%s -> background video inserted: %s', async (reduce, expectVideo) => {
+    stubReducedMotion(reduce);
+
+    const { default: jarallax } = await import('../src/core.ts');
+    const { default: jarallaxVideo } = await import('../src/ext-video.ts');
+    const block = createJarallaxBlock({ mode: 'img' });
+
+    jarallaxVideo(jarallax);
+    jarallax(block, { videoSrc: 'https://youtu.be/mru3Q5m4lkY' });
+
+    block.jarallax.isElementInViewport = true;
+    jarallax(block, 'onScroll');
+
+    expect(Boolean(block.querySelector('iframe'))).toBe(expectVideo);
+    expect(block.jarallax.options.disableVideo()).toBe(reduce);
+  });
+
+  it('keeps the poster visible instead of the player when motion is reduced', async () => {
+    stubReducedMotion(true);
+
+    const { default: jarallax } = await import('../src/core.ts');
+    const { default: jarallaxVideo } = await import('../src/ext-video.ts');
+    const block = createJarallaxBlock({ mode: 'background' });
+
+    jarallaxVideo(jarallax);
+    jarallax(block, { videoSrc: 'https://youtu.be/mru3Q5m4lkY' });
+
+    block.jarallax.isElementInViewport = true;
+    jarallax(block, 'onScroll');
+
+    // The author's own background survives, and no provider player was ever asked for.
+    expect(block.jarallax.image.bgImage).toContain('https://via.placeholder.com/100x50');
+    expect(block.querySelector('iframe')).toBeNull();
+    expect(videoWorkerState.instances[0].play).not.toHaveBeenCalled();
+  });
+});

--- a/tests/reduced-motion.test.js
+++ b/tests/reduced-motion.test.js
@@ -11,7 +11,11 @@ vi.mock('video-worker', () => {
       this.source = source;
       this.options = options;
       this.handlers = new Map();
-      this.type = source.includes('vimeo.com') ? 'vimeo' : 'youtube';
+      this.type = source.startsWith('mp4:')
+        ? 'local'
+        : source.includes('vimeo.com')
+          ? 'vimeo'
+          : 'youtube';
       this.videoID = 'mru3Q5m4lkY';
       this.videoWidth = 1280;
       this.videoHeight = 720;
@@ -32,10 +36,10 @@ vi.mock('video-worker', () => {
 
     getVideo(callback) {
       const hidden = document.createElement('div');
-      const iframe = document.createElement('iframe');
-      hidden.appendChild(iframe);
+      const node = document.createElement(this.type === 'local' ? 'video' : 'iframe');
+      hidden.appendChild(node);
       document.body.appendChild(hidden);
-      callback(iframe);
+      callback(node);
     }
 
     play = vi.fn();
@@ -98,7 +102,8 @@ describe('prefers-reduced-motion', () => {
     jarallax(block, 'onScroll');
 
     expect(Boolean(block.querySelector('iframe'))).toBe(expectVideo);
-    expect(block.jarallax.options.disableVideo()).toBe(reduce);
+    // `disableVideo` keeps reporting only what the author asked for.
+    expect(block.jarallax.options.disableVideo()).toBe(false);
   });
 
   it('keeps the poster visible instead of the player when motion is reduced', async () => {
@@ -118,5 +123,70 @@ describe('prefers-reduced-motion', () => {
     expect(block.jarallax.image.bgImage).toContain('https://via.placeholder.com/100x50');
     expect(block.querySelector('iframe')).toBeNull();
     expect(videoWorkerState.instances[0].play).not.toHaveBeenCalled();
+  });
+
+  // A self-hosted video with no fallback image has nothing else to show, so it is inserted
+  // paused. The placeholder poster must stay off or it would hide the frame.
+  it('inserts a self-hosted video paused when the element has no fallback image', async () => {
+    stubReducedMotion(true);
+
+    const { default: jarallax } = await import('../src/core.ts');
+    const { default: jarallaxVideo } = await import('../src/ext-video.ts');
+    const block = document.createElement('div');
+    block.className = 'jarallax';
+    document.body.appendChild(block);
+
+    jarallaxVideo(jarallax);
+    jarallax(block, { videoSrc: 'mp4:../demo/video/video.mp4' });
+
+    block.jarallax.isElementInViewport = true;
+    jarallax(block, 'onScroll');
+
+    const inserted = block.querySelector('video');
+
+    expect(inserted).toBeTruthy();
+    expect(inserted.getAttribute('poster')).toBeNull();
+    expect(inserted.style.objectFit).toBe('cover');
+    expect(videoWorkerState.instances[0].options.autoplay).toBe(false);
+    expect(videoWorkerState.instances[0].play).not.toHaveBeenCalled();
+  });
+
+  it('skips the self-hosted video when the element already has a fallback image', async () => {
+    stubReducedMotion(true);
+
+    const { default: jarallax } = await import('../src/core.ts');
+    const { default: jarallaxVideo } = await import('../src/ext-video.ts');
+    const block = createJarallaxBlock({ mode: 'background' });
+
+    jarallaxVideo(jarallax);
+    jarallax(block, { videoSrc: 'mp4:../demo/video/video.mp4' });
+
+    block.jarallax.isElementInViewport = true;
+    jarallax(block, 'onScroll');
+
+    expect(block.querySelector('video')).toBeNull();
+    expect(block.jarallax.image.bgImage).toContain('https://via.placeholder.com/100x50');
+  });
+
+  it('keeps autoplay and the poster when motion is not reduced', async () => {
+    stubReducedMotion(false);
+
+    const { default: jarallax } = await import('../src/core.ts');
+    const { default: jarallaxVideo } = await import('../src/ext-video.ts');
+    const block = document.createElement('div');
+    block.className = 'jarallax';
+    document.body.appendChild(block);
+
+    jarallaxVideo(jarallax);
+    jarallax(block, { videoSrc: 'mp4:../demo/video/video.mp4' });
+
+    block.jarallax.isElementInViewport = true;
+    jarallax(block, 'onScroll');
+
+    const inserted = block.querySelector('video');
+
+    expect(inserted).toBeTruthy();
+    expect(inserted.getAttribute('poster')).toContain('data:image/gif;base64,');
+    expect(videoWorkerState.instances[0].options.autoplay).toBe(true);
   });
 });

--- a/tests/video-dom.test.js
+++ b/tests/video-dom.test.js
@@ -137,4 +137,24 @@ describe('jarallax video DOM integration', () => {
     expect(worker.options.mute).toBe(expectedMute);
     expect(worker.options.volume).toBe(Number(attr));
   });
+
+  it('forwards the player host options and leaves them undefined when unset', async () => {
+    const { default: jarallax } = await import('../src/core.ts');
+    const { default: jarallaxVideo } = await import('../src/ext-video.ts');
+    const block = createJarallaxBlock({ mode: 'img' });
+    const other = createJarallaxBlock({ mode: 'img' });
+
+    jarallaxVideo(jarallax);
+    jarallax(block, {
+      videoSrc: 'https://youtu.be/mru3Q5m4lkY',
+      videoYoutubeHost: 'https://www.youtube-nocookie.com',
+    });
+    jarallax(other, { videoSrc: 'https://youtu.be/mru3Q5m4lkY' });
+
+    const [withHost, withoutHost] = videoWorkerState.instances;
+
+    expect(withHost.options.youtubeHost).toBe('https://www.youtube-nocookie.com');
+    expect(withoutHost.options.youtubeHost).toBeUndefined();
+    expect(withoutHost.options.vimeoHost).toBeUndefined();
+  });
 });


### PR DESCRIPTION
A reader whose system asks for reduced motion still got the full parallax and an autoplaying background video. Both now stop on their own, with nothing to configure.

On the parallax side the implementation adds no new rendering state: `(prefers-reduced-motion: reduce)` folds into the `disableParallax` check, so a reduced-motion visitor lands on exactly the layout that option has always produced — a path already used for the mobile fallback and already covered by tests. The video side is decided separately, because what should replace the video depends on the provider, and `disableVideo` should keep meaning only what the author asked for.

| Background | Reduced motion shows |
| :--- | :--- |
| Image | The image, positioned as usual, not moving |
| YouTube / Vimeo | The provider thumbnail; the iframe is never requested |
| Self-hosted, with a fallback image | That image; the video is never requested |
| Self-hosted, no fallback image | The video's own first frame, inserted paused |

Skipping the provider iframe rather than inserting-and-pausing it is deliberate: the thumbnail is already painted as the container background, so there is nothing to gain from several hundred kilobytes of player for someone who will not see it move.

## The self-hosted case

A self-hosted video has no thumbnail to borrow, so an element with no image of its own would have gone blank — trading motion sickness for an empty hero is not a win. It is inserted paused instead, which works because of one measured detail:

| paused `<video>` | first frame painted |
| :--- | :--- |
| `preload="metadata"`, no poster | **yes**, at `currentTime=0` |
| `preload="metadata"`, placeholder poster | **no** |

The placeholder poster is a transparent 1×1 GIF, and it is what would have covered the frame. So in this one case the poster is left off and `object-fit: cover` is set directly — `started` never fires, so `coverImage()` never gets a chance to size the element itself.

## Verified in Chrome 151

Playwright's `reducedMotion` emulation sets the real media feature, so this exercises the actual query rather than a stub.

```
reduce           img container=false moved=false   remote iframe=false  speed=1
                 self-hosted: inserted, poster=null, object-fit=cover,
                              paused=true, t=0.00, frame painted=YES
no-preference    img container=true  moved=true    remote iframe=true   speed=0.4
                 self-hosted: inserted, poster set, playing, t=0.90
```

The frame check samples the element through a canvas and measures luminance range, so "painted" means real pixels, not just a `readyState`. The control run is the point: nothing changes when the preference is not set.

Reduced motion is read when the instance is created. Toggling the system setting applies on the next page load; making it live means destroying and re-creating instances behind React's and jQuery's backs, which did not seem worth it for how rarely the setting changes mid-session.

## Also in here

- `videoYoutubeHost` and `videoVimeoHost`, forwarded to the options added in video-worker 3.1.0. They follow the existing `video*` prefix so the data attributes stay grouped (`data-video-youtube-host`). Left unset they pass `undefined`, which video-worker's `extend` skips, so its own default is never pinned here a second time.
- `video-worker` bumped to `^3.1.0` — Vimeo backgrounds no longer play muted in Chrome, and YouTube moves off the nocookie host.
- `npm install` alphabetized two `@types/react*` lines in `package.json`. Incidental, not mine.

`npm run lint`, `format:check`, `typecheck` and `test:run` (50 tests) pass. The new tests cover both directions for image and video backgrounds, the poster-only insertion, and that no player is requested or played under reduced motion.

Unrelated, noticed while testing: calling `jarallaxVideo()` by hand on top of the UMD bundle, which already calls it, patches the prototype twice and corrupts `defaultInitImgResult`. Pre-existing, not touched here.